### PR TITLE
Add StructEval chart-code benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@
 - [ChartCoder (ACL 2025)](https://aclanthology.org/2025.acl-long.363/) - Multimodal LLM for chart-to-code generation, 7B model outperforms larger open-source MLLMs
 - [ChartAssistant / ChartAst (ACL 2024)](https://github.com/OpenGVLab/ChartAst) - Universal chart comprehension and reasoning model
 - [Chart-to-Text Datasets](https://github.com/vis-nlp/Chart-to-text) - Large-scale chart summarization datasets for training chart description capabilities
+- [StructEval (TMLR 2025)](https://tiger-ai-lab.github.io/StructEval/) - [Paper](https://openreview.net/forum?id=buDwV7LUA7) and [code](https://github.com/TIGER-AI-Lab/StructEval) for benchmarking LLM-generated Matplotlib, Vega, SVG, TikZ, and web UI outputs with rendering and visual checks
 
 ### Scientific Visualization Tools
 - [Chat2Plot](https://github.com/nyanp/chat2plot) - Secure text-to-visualization through standardized chart specifications


### PR DESCRIPTION
## Project

- Name: StructEval
- URL: https://tiger-ai-lab.github.io/StructEval/
- Category: Chart Understanding & Generation → Chart-to-Code & Reproducibility

## Why it belongs

StructEval is a TMLR 2025 benchmark for LLM generation and conversion across 2,035 examples, 18 structured formats, and 44 task types. Its renderable subset covers Matplotlib, Vega, SVG, TikZ, LaTeX, Mermaid, and web UI code, checking successful rendering and visual correctness through VQA. It complements the section's specialized chart-to-code and chart-understanding resources with cross-format evaluation.

## Quality signals

- License: Apache-2.0
- Maintenance status: Active, with an official public leaderboard and current repository updates
- Documentation/examples: Project page documents the dataset, rendered examples, evaluation pipeline, and model results
- Distinction from similar projects: Jointly evaluates generation and format conversion using structural, rendering, and visual checks

## Validation

- `git diff --check`
- Verified the official project, paper, and code links.
- Confirmed the entry follows the existing one-line resource format and section placement.

## Disclosure

I am a maintainer of StructEval. This contribution was prepared with assistance from OpenAI Codex.
