### PR TITLE
Add Academic Paper Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 - [Connected Papers](https://www.connectedpapers.com/) - AI-powered visual graph for exploring academic papers and discovering connected research through citation networks and semantic similarity
 - [PaSa (ByteDance)](https://github.com/bytedance/pasa) - Advanced paper search agent powered by large language models, autonomously invoking search tools, reading papers, and selecting references to deliver comprehensive and accurate results for complex scholarly queries (1.5K+ stars, Apache 2.0, 2024)
 - [paper-search-mcp](https://github.com/openags/paper-search-mcp) - MCP server, CLI, and agent skills for searching and downloading academic papers from multiple open sources (arXiv, PubMed, bioRxiv, Semantic Scholar, OpenAlex, CORE, Europe PMC, etc.) with unified, deduplicated, LLM-friendly retrieval and an OA-first download fallback chain (OpenAGS, 1.9K+ stars, MIT License, 2025)
+- [Academic Paper Search](https://github.com/wp-a/nature-academic-search) - Multi-source literature search Skill and MCP for Codex and Claude Code, with deduplication, citation verification, and reference exports
 
 ### Data Analysis & Visualization
 - [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) - Conversational data analysis using natural language


### PR DESCRIPTION
Adds Academic Paper Search under Literature & Knowledge Management.

The project provides a public MIT-licensed Skill and MCP server for multi-source literature search in Codex and Claude Code, including deduplication, identifier verification, and reference exports.

Maintainer disclosure: I maintain Academic Paper Search.
Automation disclosure: this submission was prepared with an automated coding assistant.

Validation:
- repository and documentation links checked
- capability wording matched to the current project README
- git diff --check