### PR TITLE
Add ScholarCopilot to Scientific Writing & Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 - [Research Rabbit](https://www.researchrabbit.ai/) - AI-powered literature discovery and research network mapping
 - [SciWrite](https://github.com/labarba/sciwrite) - Agent skill for AI-assisted scientific manuscript writing review distilled from Stanford's *Writing in the Sciences* course, performing five sequential editorial audit passes on clarity, voice, structure, consistency, and integrity (2026)
 - [Claude Prism](https://github.com/delibae/claude-prism) - Offline-first scientific writing workspace powered by Claude, integrating LaTeX, Python, and 100+ scientific skills with local execution, Zotero integration, and privacy-focused design (2026)
+- [ScholarCopilot](https://github.com/TIGER-AI-Lab/ScholarCopilot) - Open-weight (Qwen-2.5-7B) academic-writing assistant that jointly trains retrieval and generation, emitting a `[RET]` token to fetch and insert accurate citations from a 500K-paper corpus with one-click BibTeX; live HuggingFace demo, COLM 2025 (TIGER-AI-Lab, 2025)
 
 ---
 


### PR DESCRIPTION
Adds ScholarCopilot to "Scientific Writing & Collaboration".

ScholarCopilot (COLM 2025, arXiv:2504.00824, TIGER-AI-Lab) is an open-weight academic-writing assistant that learns *when* to cite (a `[RET]` retrieval token), pulls references from a 500K-paper corpus, and inserts citations + BibTeX in one click — jointly optimizing retrieval and generation rather than bolting RAG onto a frozen LLM.

- Paper: https://arxiv.org/abs/2504.00824
- Code (MIT): https://github.com/TIGER-AI-Lab/ScholarCopilot
- Model / demo: https://huggingface.co/TIGER-Lab/ScholarCopilot-v1

Follows the existing list format (name - description - year); complements the RAG-analysis tools (PaperQA2, OpenScholar) by focusing on drafting. Happy to move it under "Scientific Literature RAG & Analysis" if you prefer.