### PR TITLE
Add Mydentify AI Watermark Detector

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@
 - [Label Studio](https://github.com/heartexlabs/label-studio) - Multi-type data labeling and annotation tool
 - [Snorkel](https://github.com/snorkel-team/snorkel) - Programmatic data labeling and weak supervision
 
+### AI Authenticity & Provenance
+- [Mydentify AI Watermark Detector](https://mydentify.com/tools/ai-watermark-detector) - Browser-based checks for observable AI-text signals, with explicit limits on what text-only evidence can prove
+
 ### Research Workbench & Plugins
 - [Claude Scientific Skills](https://github.com/K-Dense-AI/claude-scientific-skills) - Comprehensive collection of 125+ ready-to-use scientific skill modules for Claude AI across bioinformatics, cheminformatics, clinical research, ML, and materials science
 - [GDM Science Skills](https://github.com/google-deepmind/science-skills) - Google DeepMind's official collection of agentic science skills accelerating scientific workflows with better grounding and higher token efficiency, integrating insights from AlphaGenome, AFDB, UniProt and 30+ other databases and tools (2026)


### PR DESCRIPTION
## Summary

- Add the free [Mydentify AI Watermark Detector](https://mydentify.com/tools/ai-watermark-detector) to the AI Tools for Research collection.
- Place it under a focused AI Authenticity & Provenance subsection.
- Describe the tool neutrally: it checks observable AI-text signals and states what text-only evidence cannot prove.

## Quality and fit

- The HTTPS tool page returns HTTP 200 and is publicly accessible without an account or paid plan.
- The entry links to the dedicated tool page rather than a tracking URL.
- The description makes no authorship, private-watermark, or certainty claim.
- I am the maintainer of the linked project and am disclosing that relationship for review.
- No reciprocal link, vote, review, payment, or engagement is requested.

If the maintainers prefer a different section, I am happy to move the single entry.