### PR TITLE
Add Lune Research to scientific literature tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@
 
 ### Scientific Literature RAG & Analysis
 - [PaperQA2](https://github.com/future-house/paper-qa) - High-accuracy RAG for scientific PDFs with citation support, agentic RAG, and contradiction detection
+- [Lune Research](https://github.com/RetrogradeLabs/lune-mcp-server) - MCP server that searches full-text peer-reviewed papers, traces citations, extracts evidence, verifies claims, and retrieves methodology guidance
 - [OpenScholar](https://github.com/AkariAsai/OpenScholar) - Retrieval-augmented LM synthesizing scientific literature from 45M papers with human-expert-level citation accuracy, outperforming GPT-4o by 5% on ScholarQABench (Nature 2026, UW & Ai2)
 - [Valsci](https://github.com/bricee98/Valsci) - Self-hostable scientific claim-verification and literature-review tool combining Semantic Scholar retrieval, bibliometric scoring, and LLM-based evidence synthesis for large-batch validation workflows
 - [paper-reviewer](https://github.com/deep-diver/paper-reviewer) - Generate comprehensive reviews from arXiv papers and convert to blog posts


### PR DESCRIPTION
Adds Lune Research to the Scientific Literature RAG and Analysis section.

Lune is an MIT-licensed MCP server for AI research agents. It searches full text from peer-reviewed papers at top ML, NLP, vision, systems, and security venues. It also traverses citation graphs, extracts structured evidence, checks claims against verbatim quotes, and retrieves curated research-methodology guidance.

The entry links directly to the public server repository and uses a factual 18-word description, within the contribution guide limit. I checked the list for duplicate names and repository URLs before submitting.