### PR TITLE
Add Research Gap Finder to Literature & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@
 - [Connected Papers](https://www.connectedpapers.com/) - AI-powered visual graph for exploring academic papers and discovering connected research through citation networks and semantic similarity
 - [PaSa (ByteDance)](https://github.com/bytedance/pasa) - Advanced paper search agent powered by large language models, autonomously invoking search tools, reading papers, and selecting references to deliver comprehensive and accurate results for complex scholarly queries (1.5K+ stars, Apache 2.0, 2024)
 - [paper-search-mcp](https://github.com/openags/paper-search-mcp) - MCP server, CLI, and agent skills for searching and downloading academic papers from multiple open sources (arXiv, PubMed, bioRxiv, Semantic Scholar, OpenAlex, CORE, Europe PMC, etc.) with unified, deduplicated, LLM-friendly retrieval and an OA-first download fallback chain (OpenAGS, 1.9K+ stars, MIT License, 2025)
+- [Research Gap Finder (Science AI Journal)](https://scienceaijournal.com/research-gaps) - Surfaces open, unanswered research questions in any field from 120,000+ gaps mined across a 4.5M-paper library, each linked to the key literature that raised it, with a live field snapshot from 250M+ OpenAlex works
 
 ### Data Analysis & Visualization
 - [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) - Conversational data analysis using natural language

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 - [Connected Papers](https://www.connectedpapers.com/) - AI-powered visual graph for exploring academic papers and discovering connected research through citation networks and semantic similarity
 - [PaSa (ByteDance)](https://github.com/bytedance/pasa) - Advanced paper search agent powered by large language models, autonomously invoking search tools, reading papers, and selecting references to deliver comprehensive and accurate results for complex scholarly queries (1.5K+ stars, Apache 2.0, 2024)
 - [paper-search-mcp](https://github.com/openags/paper-search-mcp) - MCP server, CLI, and agent skills for searching and downloading academic papers from multiple open sources (arXiv, PubMed, bioRxiv, Semantic Scholar, OpenAlex, CORE, Europe PMC, etc.) with unified, deduplicated, LLM-friendly retrieval and an OA-first download fallback chain (OpenAGS, 1.9K+ stars, MIT License, 2025)
-- [Research Gap Finder (Science AI Journal)](https://scienceaijournal.com/research-gaps) - Surfaces open, unanswered research questions in any field from 120,000+ gaps mined across a 4.5M-paper library, each linked to the key literature that raised it, with a live field snapshot from 250M+ OpenAlex works
+- [Research Gap Finder (Science AI Journal)](https://scienceaijournal.com/research-gaps) - Surfaces open, unanswered research questions in any field from 120,000+ gaps mined across a 4.5M-paper library, each linked to the key literature that raised it
 
 ### Data Analysis & Visualization
 - [PandasAI](https://github.com/Sinaptik-AI/pandas-ai) - Conversational data analysis using natural language


### PR DESCRIPTION
Adds **Research Gap Finder** to *Literature & Knowledge Management*, alongside the section's other literature-discovery tools (Semantic Scholar, Connected Papers, PaSa).

It surfaces open, unanswered research questions in any field from 120,000+ gaps mined across a 4.5M-paper library, each linked to the paper that raised it. Hosted tool, free account to start. Happy to tweak the wording or placement.

Disclosure: I maintain Science AI Journal — happy for you to weigh that when deciding.