### PR TITLE
Add BrainPilot research platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@
 ## 🧰 Research Workbench & Plugins
 
 ### Interactive Research Environments
+- [BrainPilot](https://github.com/NeuroAIHub/BrainPilot) - Open-source multi-agent research platform with cloud access, extensible scientific tools, human oversight, and visual execution traces.
 - [Jupyter AI (JupyterLab Extension)](https://github.com/jupyterlab/jupyter-ai) - Official Jupyter extension with `%%ai` magic commands and sidebar chat assistant, connecting multiple model providers and local inference
 - [Notebook Intelligence (NBI)](https://github.com/notebook-intelligence/notebook-intelligence) - AI coding assistant for JupyterLab with agent mode, supporting arbitrary LLM providers (2025+)
 - [Google Colab AI Features](https://colab.research.google.com/) - Integrated AI assistance for data science and research notebooks


### PR DESCRIPTION
Adds BrainPilot to Interactive Research Environments.

BrainPilot is an open-source multi-agent platform for scientific research, available for self-hosting and through a hosted cloud platform. A coordinating PI agent works with specialist agents across literature research, study design, coding, data analysis, writing, and audit. It supports configurable model providers, extensible skills and tools, human oversight, and an inspectable Graph of Trace. Its current public examples and evaluations focus on brain science.

- Repository and setup: https://github.com/NeuroAIHub/BrainPilot
- Hosted platform: https://brainpilot.chat
- Documentation: https://brainpilot.chat/docs
- Technical report: https://arxiv.org/abs/2607.15079

Validation: checked the contribution guide, searched for existing BrainPilot entries and submissions, verified the linked resources, and kept the entry under the 20-word description limit. This PR adds one entry only.
