### PR TITLE
Add PaperAgent — local literature workbench (parse → knowledge compile → translate → QA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 - [STORM](https://github.com/stanford-oval/storm) - LLM agent system synthesizing Wikipedia-like long-form research articles from scratch through multi-perspective question asking, web retrieval, and citation-grounded report generation, with Co-STORM extension for collaborative human-LLM knowledge curation conversations (Stanford OVAL, NAACL 2024 & EMNLP 2024)
 
 ---
+- [PaperAgent](https://github.com/hui-xu-ai/PaperAgent) - Local-first literature workbench for Windows: MinerU parsing with a dual-channel human review UI, three-level knowledge compilation (L1/L2/L3 notes), full-text translation and FTS5 retrieval QA over your own PDFs (MIT)
 
 ## 🧰 Research Workbench & Plugins
 


### PR DESCRIPTION
Adds PaperAgent to **Scientific Literature RAG & Analysis**.

**What it is:** a local-first, single-user literature workbench. It parses scientific PDFs
(MinerU v4 + dual-channel character arbitration with a human review UI), compiles three-level
knowledge notes (L1 note → L2 section digest → L3 deep wiki, value-score ranked), optionally
translates full text, and answers questions over a local SQLite FTS5 index (notes / metadata /
citation neighbourhood / cards) with streaming output. Ships as a one-click Windows package.

**Why it fits this section:** it is a self-contained RAG pipeline over scientific PDFs where the
retrieval corpus is compiled on the user's own machine, so citations point back into the local
document (paragraph ids are kept), and nothing is uploaded except the model calls the user configures.

- Repo: https://github.com/hui-xu-ai/PaperAgent (MIT)
- Release: https://github.com/hui-xu-ai/PaperAgent/releases/tag/v1.0.0
- Format follows the guidelines in CONTRIBUTING.md (`- [Name](link) - Description`), added to the
  bottom of the section.

I maintain the project (first-hand experience of the tool). Happy to adjust wording or move it to a
different section if you prefer.